### PR TITLE
Add continuous integration with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libavif
+# libavif [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/joedrago/avif?branch=master&svg=true)](https://ci.appveyor.com/project/joedrago/avif)
 
 TBW
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ TBW
 
 You need CMake and nasm.
 
+### Windows builds
+Windows builds for x86-64 processors can be found on [AppVeyor](https://ci.appveyor.com/project/joedrago/avif) under the Artifacts tab of each build. Recommended is a build from the master branch. 
+
 ---
 
 # License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+image: Visual Studio 2017
+configuration: Release
+
+install:
+  ## Download nasm
+  - mkdir nasm
+  - cd nasm
+  - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
+  - 7z e -y nasm.zip
+  - set PATH=%PATH%;%CD%
+  ## Prepare cmake
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir cmake_build
+
+before_build:
+  - cmake --version
+  - cmake
+
+build_script: cmake_build\avif.sln
+
+artifacts:
+ - path: cmake_build\**\Release\**\*.exe
+ - path: cmake_build\**\Release\**\*.lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 
 before_build:
   - cmake --version
-  - cmake
+  - cmake %CD%
 
 build_script: cmake_build\avif.sln
 


### PR DESCRIPTION
Add continuous integration with AppVeyor for automated Windows builds. For optimal integration with GitHub, AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.

At the moment CMake produces an error when following `ext/aom/CMakeLists.txt`. Does this needs to be resolved in AppVeyor or in the CMakeList itself?
```
CMake Error at ext/aom/CMakeLists.txt:27 (message):
  Building from within the aom source tree is not supported.
  Hint: Run these commands
  $ rm -rf CMakeCache.txt CMakeFiles
  $ mkdir -p ../aom_build
  $ cd ../aom_build
  And re-run CMake from the aom_build directory.
-- Configuring incomplete, errors occurred!
See also "C:/projects/avif/CMakeFiles/CMakeOutput.log".
Command exited with code 1
```
Previous AppVeyor runs from EwoutH/avif can be found [here](https://ci.appveyor.com/project/EwoutH/avif/history).